### PR TITLE
Fix visualization utility errors

### DIFF
--- a/housing/visualization/data.py
+++ b/housing/visualization/data.py
@@ -9,7 +9,7 @@ import seaborn as sns
 from housing.config import VIS_DIR
 
 # Ensure visualization directory exists
-ios.makedirs(VIS_DIR, exist_ok=True)
+os.makedirs(VIS_DIR, exist_ok=True)
 
 def create_correlation_heatmap(train_data):
     """Generate and save a correlation heatmap of top numeric features."""

--- a/housing/visualization/runner.py
+++ b/housing/visualization/runner.py
@@ -40,5 +40,7 @@ def model(ctx, rf_pred, ridge_pred, y_val):
     y = np.load(y_val)
     plot_saleprice_distribution(pd.DataFrame({'SalePrice': y}))
     rf_res, ridge_res = plot_prediction_comparison(y, rf, ridge)
-    plot_residuals_distribution(rf_res, ridge_res, None, None)
+    rf_rmse = np.sqrt(((rf - y) ** 2).mean())
+    ridge_rmse = np.sqrt(((ridge - y) ** 2).mean())
+    plot_residuals_distribution(rf_res, ridge_res, rf_rmse, ridge_rmse)
     # further plots...


### PR DESCRIPTION
## Summary
- use `os.makedirs` in data visualization package
- calculate RMSE before plotting residual distribution in CLI runner

## Testing
- `pytest -q` *(fails: command not found)*