### PR TITLE
Fix config imports

### DIFF
--- a/housing/data.py
+++ b/housing/data.py
@@ -2,7 +2,7 @@
 Data loading and preprocessing functions
 """
 import pandas as pd
-from housing.config import TRAIN_PATH, TEST_PATH
+from config import TRAIN_PATH, TEST_PATH
 
 def load_data():
     """Load training and test datasets from CSV files."""

--- a/housing/models/random_forest.py
+++ b/housing/models/random_forest.py
@@ -1,7 +1,7 @@
 import numpy as np
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.metrics import mean_squared_error
-from housing.config import SEED
+from config import SEED
 
 def train_and_evaluate_rf(X_train, y_train, X_val, y_val):
     """

--- a/housing/models/ridge.py
+++ b/housing/models/ridge.py
@@ -4,7 +4,7 @@ from sklearn.preprocessing import StandardScaler
 from sklearn.linear_model import Ridge
 from sklearn.model_selection import GridSearchCV
 from sklearn.metrics import mean_squared_error
-from housing.config import SEED, ALPHA_GRID
+from config import SEED, ALPHA_GRID
 
 def train_and_evaluate_ridge(X_train, y_train, X_val, y_val):
     """

--- a/housing/visualization/data.py
+++ b/housing/visualization/data.py
@@ -6,10 +6,10 @@ import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
 import seaborn as sns
-from housing.config import VIS_DIR
+from config import VIS_DIR
 
 # Ensure visualization directory exists
-ios.makedirs(VIS_DIR, exist_ok=True)
+os.makedirs(VIS_DIR, exist_ok=True)
 
 def create_correlation_heatmap(train_data):
     """Generate and save a correlation heatmap of top numeric features."""

--- a/housing/visualization/model.py
+++ b/housing/visualization/model.py
@@ -7,7 +7,7 @@ import pandas as pd
 import matplotlib.pyplot as plt
 import seaborn as sns
 from sklearn.inspection import PartialDependenceDisplay
-from housing.config import VIS_DIR
+from config import VIS_DIR
 
 os.makedirs(VIS_DIR, exist_ok=True)
 


### PR DESCRIPTION
## Summary
- repair config imports in package modules
- fix typo when creating visualization directory

## Testing
- `python -m py_compile housing/data.py housing/models/random_forest.py housing/models/ridge.py housing/visualization/data.py housing/visualization/model.py`
- `python -m py_compile main.py data_visualizations.py model_visualizations.py enhanced_visualizations.py visualization_runner.py housing/modeling.py housing/visualization/runner.py`
- `python - <<'PY'
import housing.data
import housing.models.random_forest
import housing.models.ridge
import housing.visualization.data
import housing.visualization.model
PY` *(fails: ModuleNotFoundError: No module named 'pandas')*