### PR TITLE
Make frontend self-contained

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,12 @@ python main.py
 python visualization_runner.py
 ```
 
-4. Launch the simple local front end (requires Tkinter, included with Python):
+4. Launch the simple local front end (requires Tkinter and a display server):
 ```bash
 python local_frontend.py
 ```
+If no display is available, the script will exit with a message indicating that
+the `DISPLAY` environment variable is missing.
 
 ## Data Visualization Functions
 

--- a/local_frontend.py
+++ b/local_frontend.py
@@ -1,25 +1,98 @@
-import pandas as pd
-from sklearn.ensemble import RandomForestRegressor
+"""Simple Tkinter GUI for predicting housing prices.
+
+This version avoids external dependencies like ``pandas`` and
+``scikit-learn`` so that it can run in minimal environments.
+The model is a basic linear regression trained using only the
+Python standard library.
+"""
+
+import csv
+import os
+import sys
 import tkinter as tk
 from tkinter import ttk
 
 # Features to use for the simple model
-FEATURES = ['OverallQual', 'GrLivArea', 'GarageCars']
+FEATURES = ["OverallQual", "GrLivArea", "GarageCars"]
 
 def train_model():
-    """Train a simple model using selected features."""
-    data = pd.read_csv('train.csv')
-    X = data[FEATURES]
-    y = data['SalePrice']
-    model = RandomForestRegressor(n_estimators=100, random_state=42)
-    model.fit(X, y)
-    return model
+    """Train a linear regression model using only the standard library."""
+    with open("train.csv", newline="") as f:
+        reader = csv.DictReader(f)
+        X = []
+        y = []
+        for row in reader:
+            try:
+                X.append(
+                    [
+                        1.0,
+                        float(row["OverallQual"]),
+                        float(row["GrLivArea"]),
+                        float(row["GarageCars"]),
+                    ]
+                )
+                y.append(float(row["SalePrice"]))
+            except ValueError:
+                # Skip rows with missing data
+                pass
 
-model = train_model()
+    n_features = len(X[0])
+    # Compute X^T X and X^T y
+    xtx = [[0.0] * n_features for _ in range(n_features)]
+    xty = [0.0] * n_features
+    for row, target in zip(X, y):
+        for i in range(n_features):
+            xty[i] += row[i] * target
+            for j in range(n_features):
+                xtx[i][j] += row[i] * row[j]
+
+    coef = _solve_linear_system(xtx, xty)
+    return coef
+
+
+def _solve_linear_system(matrix, vector):
+    """Solve matrix * x = vector for x using Gauss-Jordan elimination."""
+    n = len(matrix)
+    # Create augmented matrix
+    aug = [row[:] + [vector[i]] for i, row in enumerate(matrix)]
+
+    for col in range(n):
+        # Find pivot
+        pivot_row = None
+        for r in range(col, n):
+            if aug[r][col] != 0:
+                pivot_row = r
+                break
+        if pivot_row is None:
+            raise ValueError("Matrix is singular")
+        if pivot_row != col:
+            aug[col], aug[pivot_row] = aug[pivot_row], aug[col]
+
+        pivot = aug[col][col]
+        # Normalize pivot row
+        for c in range(col, n + 1):
+            aug[col][c] /= pivot
+        # Eliminate other rows
+        for r in range(n):
+            if r != col:
+                factor = aug[r][col]
+                for c in range(col, n + 1):
+                    aug[r][c] -= factor * aug[col][c]
+
+    return [aug[i][n] for i in range(n)]
+
+# Pre-compute model coefficients when the module is imported
+MODEL_COEFS = train_model()
 
 # Tkinter GUI setup
+if not os.environ.get("DISPLAY"):
+    sys.stderr.write(
+        "Error: No display found. Set the DISPLAY environment variable to run the GUI.\n"
+    )
+    sys.exit(1)
+
 root = tk.Tk()
-root.title('Housing Price Predictor')
+root.title("Housing Price Predictor")
 
 entries = {}
 for feature in FEATURES:
@@ -41,8 +114,8 @@ def predict():
     except ValueError:
         result_var.set('Please enter valid numeric values.')
         return
-    sample = pd.DataFrame([values], columns=FEATURES)
-    pred = model.predict(sample)[0]
+    features_with_intercept = [1.0] + values
+    pred = sum(c * v for c, v in zip(MODEL_COEFS, features_with_intercept))
     result_var.set(f'Predicted SalePrice: ${pred:,.2f}')
 
 button = ttk.Button(root, text='Predict', command=predict)


### PR DESCRIPTION
## Summary
- replace pandas/sklearn-based GUI with lightweight linear regression and csv module
- handle missing DISPLAY variable gracefully and exit with informative message
- document DISPLAY requirement in README

## Testing
- `python -m py_compile local_frontend.py`
- `python local_frontend.py` *(fails: Error: No display found. Set the DISPLAY environment variable to run the GUI.)*