### PR TITLE
Add preprocessing pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,15 @@
 ## Setup
 - Use `requirements.txt` to install dependencies
 - Use Jupyter or VS Code for notebooks
+
+## Data Preprocessing
+
+Run the preprocessing script to convert the raw Kaggle data into a cleaned
+dataset. This replicates the steps originally performed in the Jupyter
+notebooks:
+
+```bash
+python scripts/preprocess_data.py \
+  --input data/raw/train.csv \
+  --output data/processed/V1/train_cleaned.csv
+```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,5 +2,7 @@
 
 Place Python scripts for data processing, feature engineering, and modeling here.
 
-- Example: `download_data.py` for automated data downloads.
-- Document script usage with comments or docstrings.
+- `download_data.py` - download the Kaggle dataset (requires Kaggle API)
+- `preprocess_data.py` - run the basic data cleaning steps from the notebooks
+
+All scripts provide `--help` output describing their options.

--- a/scripts/preprocess_data.py
+++ b/scripts/preprocess_data.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Command-line interface for simple preprocessing of the Kaggle housing data."""
+import argparse
+import sys
+from pathlib import Path
+
+# Add src directory to path
+script_dir = Path(__file__).resolve().parent
+project_root = script_dir.parent
+sys.path.append(str(project_root / "src"))
+
+from data_cleaner import simple_preprocess
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run simple preprocessing on housing data")
+    parser.add_argument(
+        "--input",
+        type=str,
+        default="data/raw/train.csv",
+        help="Path to the raw input CSV (default: data/raw/train.csv)",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="data/processed/V1/train_cleaned.csv",
+        help="Destination for the cleaned CSV (default: data/processed/V1/train_cleaned.csv)",
+    )
+
+    args = parser.parse_args()
+
+    print(f"Loading data from {args.input}")
+    df = simple_preprocess(args.input, args.output)
+    print(f"Saved cleaned data to {args.output} (shape: {df.shape})")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data_cleaner.py
+++ b/src/data_cleaner.py
@@ -1,0 +1,45 @@
+"""Data cleaning utilities for the Kaggle housing dataset."""
+from pathlib import Path
+from typing import Union
+
+import numpy as np
+import pandas as pd
+
+
+def simple_preprocess(input_path: Union[str, Path], output_path: Union[str, Path]) -> pd.DataFrame:
+    """Simple preprocessing routine used in the original notebook.
+
+    This function fills missing numeric values with the median of each column,
+    fills missing categorical values with the mode, encodes categorical
+    variables as integer codes and saves the cleaned DataFrame.
+
+    Parameters
+    ----------
+    input_path : str or Path
+        Path to the raw CSV file.
+    output_path : str or Path
+        Where the cleaned CSV will be written.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The cleaned DataFrame.
+    """
+    input_path = Path(input_path)
+    output_path = Path(output_path)
+
+    df = pd.read_csv(input_path)
+
+    # Fill numeric columns
+    num_cols = df.select_dtypes(include=[np.number]).columns
+    df[num_cols] = df[num_cols].fillna(df[num_cols].median())
+
+    # Fill categorical columns and encode
+    cat_cols = df.select_dtypes(include=["object"]).columns
+    for col in cat_cols:
+        df[col] = df[col].fillna(df[col].mode()[0])
+        df[col] = df[col].astype("category").cat.codes
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(output_path, index=False)
+    return df

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,0 +1,20 @@
+import pandas as pd
+from src.data_cleaner import simple_preprocess
+from pathlib import Path
+
+
+def test_simple_preprocess(tmp_path):
+    data = pd.DataFrame({
+        "A": [1, 2, None],
+        "B": ["x", None, "y"],
+    })
+    input_csv = tmp_path / "input.csv"
+    output_csv = tmp_path / "output.csv"
+    data.to_csv(input_csv, index=False)
+
+    cleaned = simple_preprocess(input_csv, output_csv)
+
+    # numeric column filled with median -> 1,2 => median 1.5 => [1,2,1.5]
+    assert cleaned["A"].isna().sum() == 0
+    assert output_csv.exists()
+


### PR DESCRIPTION
## Summary
- add `data_cleaner` module with simple preprocessing
- provide a `preprocess_data.py` CLI for reproducible processing outside notebooks
- document preprocessing in the main README and update scripts README
- add a basic unit test for the preprocessing function

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_683b45e5ab808326a89d28fa451ba6da