### PR TITLE
Add decision tree and random forest models

### DIFF
--- a/models/simple/README.md
+++ b/models/simple/README.md
@@ -1,1 +1,9 @@
-# Simple models and scripts will go here.
+# Simple Models
+
+This directory contains example baseline models for predicting house prices.
+
+Available scripts:
+
+- `linear_regression.py` - Ordinary least squares regression.
+- `decision_tree_regression.py` - Decision tree regressor.
+- `random_forest_regression.py` - Random forest regressor.

--- a/models/simple/decision_tree_regression.py
+++ b/models/simple/decision_tree_regression.py
@@ -1,0 +1,42 @@
+"""Decision Tree Regression Model for House Price Prediction"""
+import os
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from sklearn.tree import DecisionTreeRegressor
+from sklearn.metrics import mean_squared_error
+import joblib
+
+# Path to cleaned data (update if needed)
+DATA_PATH = os.path.join('..', '..', 'data', 'processed', 'V2', 'train_advanced_cleaned.csv')
+MODEL_SAVE_PATH = os.path.join('..', 'simple', 'decision_tree_model.pkl')
+
+
+def main():
+    # 1. Load data
+    df = pd.read_csv(DATA_PATH)
+    if 'SalePrice' not in df.columns:
+        raise ValueError('SalePrice column not found in data.')
+    X = df.drop('SalePrice', axis=1)
+    y = df['SalePrice']
+
+    # 2. Split data
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
+    )
+
+    # 3. Train model
+    model = DecisionTreeRegressor(random_state=42)
+    model.fit(X_train, y_train)
+
+    # 4. Evaluate
+    preds = model.predict(X_test)
+    rmse = mean_squared_error(y_test, preds, squared=False)
+    print(f'Decision Tree RMSE: {rmse:.2f}')
+
+    # 5. Save model
+    joblib.dump(model, MODEL_SAVE_PATH)
+    print(f'Model saved to {MODEL_SAVE_PATH}')
+
+
+if __name__ == '__main__':
+    main()

--- a/models/simple/random_forest_regression.py
+++ b/models/simple/random_forest_regression.py
@@ -1,0 +1,42 @@
+"""Random Forest Regression Model for House Price Prediction"""
+import os
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.metrics import mean_squared_error
+import joblib
+
+# Path to cleaned data (update if needed)
+DATA_PATH = os.path.join('..', '..', 'data', 'processed', 'V2', 'train_advanced_cleaned.csv')
+MODEL_SAVE_PATH = os.path.join('..', 'simple', 'random_forest_model.pkl')
+
+
+def main():
+    # 1. Load data
+    df = pd.read_csv(DATA_PATH)
+    if 'SalePrice' not in df.columns:
+        raise ValueError('SalePrice column not found in data.')
+    X = df.drop('SalePrice', axis=1)
+    y = df['SalePrice']
+
+    # 2. Split data
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
+    )
+
+    # 3. Train model
+    model = RandomForestRegressor(n_estimators=100, random_state=42)
+    model.fit(X_train, y_train)
+
+    # 4. Evaluate
+    preds = model.predict(X_test)
+    rmse = mean_squared_error(y_test, preds, squared=False)
+    print(f'Random Forest RMSE: {rmse:.2f}')
+
+    # 5. Save model
+    joblib.dump(model, MODEL_SAVE_PATH)
+    print(f'Model saved to {MODEL_SAVE_PATH}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add decision tree and random forest models to `models/simple`
- document the simple models available

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement numpy>=1.21.0)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_683b517aa3a8832687be76602359e678