### PR TITLE
Add config-driven correlation analysis runner

### DIFF
--- a/notebooks/correlation_analysis_README.md
+++ b/notebooks/correlation_analysis_README.md
@@ -75,6 +75,10 @@ python scripts/correlation_analysis_runner.py \
 python scripts/correlation_analysis_runner.py \
     --data data/processed/V1/train_cleaned.csv \
     --quick
+
+# Using a configuration file
+python scripts/correlation_analysis_runner.py \
+    --config config/correlation_analysis_config.yaml
 ```
 
 ### 3. Programmatic Usage

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,5 +5,8 @@ Place Python scripts for data processing, feature engineering, and modeling here
 - `download_data.py` - download the Kaggle dataset (requires Kaggle API)
 - `preprocess_data.py` - run the data cleaning steps from the notebooks.
   Use `--method advanced` for scaling and one-hot encoding.
+- `correlation_analysis_runner.py` - perform correlation analysis on the
+  processed data. Supports a `--config` option to load settings from
+  `config/correlation_analysis_config.yaml`.
 
 All scripts provide `--help` output describing their options.


### PR DESCRIPTION
## Summary
- add YAML config loader to `correlation_analysis_runner.py`
- document new option in `scripts/README.md`
- update correlation analysis README with config-based example

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas and numpy)*

------
https://chatgpt.com/codex/tasks/task_b_683b6324ae9c8326a5ea8e5af8047971