### PR TITLE
Add data analysis summary option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,13 @@ python scripts/preprocess_data.py \
   --input data/raw/train.csv \
   --output data/processed/V2/train_preprocessed.csv
 ```
+
+Use the `--analyze` flag to display a quick summary of the dataset before
+running the preprocessing routine:
+
+```bash
+python scripts/preprocess_data.py \
+  --analyze \
+  --input data/raw/train.csv \
+  --output data/processed/V1/train_cleaned.csv
+```

--- a/scripts/preprocess_data.py
+++ b/scripts/preprocess_data.py
@@ -10,6 +10,7 @@ project_root = script_dir.parent
 sys.path.append(str(project_root / "src"))
 
 from data_cleaner import simple_preprocess, advanced_preprocess
+from data_analyzer import summarize_csv
 
 
 def main() -> None:
@@ -32,10 +33,23 @@ def main() -> None:
         default="simple",
         help="Preprocessing strategy to use (simple or advanced)",
     )
+    parser.add_argument(
+        "--analyze",
+        action="store_true",
+        help="Display a summary of the dataset before preprocessing",
+    )
 
     args = parser.parse_args()
 
     print(f"Loading data from {args.input}")
+
+    if args.analyze:
+        try:
+            summary = summarize_csv(args.input)
+            print("\nDataset summary:\n" + summary.to_string(index=False))
+        except Exception as exc:
+            print(f"Failed to analyze dataset: {exc}")
+
     if args.method == "advanced":
         df = advanced_preprocess(args.input, args.output)
     else:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,11 @@
-# src package
+"""Utility modules for the Housing project."""
 
-# This file makes the src directory a Python package.
+from .data_cleaner import simple_preprocess, advanced_preprocess
+from .data_analyzer import analyze_dataframe, summarize_csv
+
+__all__ = [
+    "simple_preprocess",
+    "advanced_preprocess",
+    "analyze_dataframe",
+    "summarize_csv",
+]

--- a/src/data_analyzer.py
+++ b/src/data_analyzer.py
@@ -1,0 +1,39 @@
+import pandas as pd
+from pathlib import Path
+from typing import Union
+
+
+def analyze_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    """Return a summary of basic statistics for each column in *df*.
+
+    The summary includes the column dtype, number of missing values,
+    percentage missing, and number of unique values. For numeric
+    columns additional statistics such as mean, standard deviation,
+    minimum and maximum are provided.
+    """
+    summary = []
+    for col in df.columns:
+        series = df[col]
+        info = {
+            "column": col,
+            "dtype": series.dtype.name,
+            "missing": series.isna().sum(),
+            "missing_pct": round(series.isna().mean() * 100, 2),
+            "unique": series.nunique(dropna=True),
+        }
+        if pd.api.types.is_numeric_dtype(series):
+            info.update(
+                mean=round(series.mean(), 3),
+                std=round(series.std(), 3),
+                min=round(series.min(), 3),
+                max=round(series.max(), 3),
+            )
+        summary.append(info)
+    return pd.DataFrame(summary)
+
+
+def summarize_csv(path: Union[str, Path]) -> pd.DataFrame:
+    """Load a CSV file and return :func:`analyze_dataframe` output."""
+    path = Path(path)
+    df = pd.read_csv(path)
+    return analyze_dataframe(df)

--- a/tests/test_data_analyzer.py
+++ b/tests/test_data_analyzer.py
@@ -1,0 +1,16 @@
+import pandas as pd
+from src.data_analyzer import analyze_dataframe
+
+
+def test_analyze_dataframe_basic():
+    df = pd.DataFrame({
+        "A": [1, 2, None],
+        "B": ["x", "y", "y"],
+    })
+    summary = analyze_dataframe(df)
+    # ensure one missing value in column A
+    a_row = summary[summary["column"] == "A"].iloc[0]
+    assert a_row["missing"] == 1
+    # categorical column unique count
+    b_row = summary[summary["column"] == "B"].iloc[0]
+    assert b_row["unique"] == 2


### PR DESCRIPTION
## Summary
- export new data analysis utilities
- add script option to print summary statistics before preprocessing
- document new `--analyze` flag
- test coverage for `analyze_dataframe`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_683b66bee8088326b66f2193bc738bb3