### PR TITLE
Add model benchmarking script

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,13 @@ python scripts/preprocess_data.py \
   --input data/raw/train.csv \
   --output data/processed/V2/train_preprocessed.csv
 ```
+
+## Model Benchmarking
+
+Use the benchmarking script to train a few standard scikit-learn models and compare their performance. The script reports RMSE, MAE and R² on a hold-out test split.
+
+```bash
+python scripts/benchmark_models.py --data data/processed/V2/train_advanced_cleaned.csv
+```
+
+Pass `--output results.csv` to save the table of results.

--- a/scripts/benchmark_models.py
+++ b/scripts/benchmark_models.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Benchmark several regression models on the housing dataset."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+# Add src directory to path
+import sys
+sys.path.append(str(Path(__file__).parent.parent / 'src'))
+
+from model_evaluator import benchmark_regressors
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compare regression models")
+    parser.add_argument(
+        "--data",
+        type=str,
+        default="data/processed/V2/train_advanced_cleaned.csv",
+        help="Path to the processed training data",
+    )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="SalePrice",
+        help="Name of the target column",
+    )
+    parser.add_argument(
+        "--test-size",
+        type=float,
+        default=0.2,
+        help="Fraction of data used for testing",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Optional path to save the results as CSV",
+    )
+
+    args = parser.parse_args()
+
+    df = pd.read_csv(args.data)
+
+    results = benchmark_regressors(
+        df, target=args.target, test_size=args.test_size
+    )
+
+    print("\nModel benchmark results (sorted by RMSE):")
+    print(results.to_string(index=False))
+
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        results.to_csv(output_path, index=False)
+        print(f"Results saved to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/model_evaluator.py
+++ b/src/model_evaluator.py
@@ -1,0 +1,66 @@
+"""Utility functions for benchmarking regression models."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import mean_squared_error, mean_absolute_error, r2_score
+from sklearn.linear_model import LinearRegression
+from sklearn.tree import DecisionTreeRegressor
+from sklearn.ensemble import RandomForestRegressor, GradientBoostingRegressor
+
+
+def benchmark_regressors(
+    df: pd.DataFrame,
+    target: str = "SalePrice",
+    test_size: float = 0.2,
+    random_state: int = 42,
+) -> pd.DataFrame:
+    """Train several regression models and return evaluation metrics.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Dataset containing features and the target column.
+    target : str, default "SalePrice"
+        Name of the target variable.
+    test_size : float, default 0.2
+        Fraction of data used for testing.
+    random_state : int, default 42
+        Random seed for the train/test split and models.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Table with metrics (RMSE, MAE, R2) sorted by RMSE.
+    """
+    if target not in df.columns:
+        raise ValueError(f"Target column '{target}' not found in data.")
+
+    X = df.drop(target, axis=1)
+    y = df[target]
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=test_size, random_state=random_state
+    )
+
+    models: Dict[str, object] = {
+        "Linear Regression": LinearRegression(),
+        "Decision Tree": DecisionTreeRegressor(random_state=random_state),
+        "Random Forest": RandomForestRegressor(n_estimators=100, random_state=random_state),
+        "Gradient Boosting": GradientBoostingRegressor(random_state=random_state),
+    }
+
+    results: List[Dict[str, float]] = []
+
+    for name, model in models.items():
+        model.fit(X_train, y_train)
+        preds = model.predict(X_test)
+        rmse = mean_squared_error(y_test, preds, squared=False)
+        mae = mean_absolute_error(y_test, preds)
+        r2 = r2_score(y_test, preds)
+        results.append({"Model": name, "RMSE": rmse, "MAE": mae, "R2": r2})
+
+    results_df = pd.DataFrame(results).sort_values("RMSE").reset_index(drop=True)
+    return results_df


### PR DESCRIPTION
## Summary
- add `benchmark_models.py` script to compare models
- add `model_evaluator` module with `benchmark_regressors`
- document model benchmarking in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_683b66eae8808326be904e96a5ac1108