### PR TITLE
Improve agent docs and README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Repository Guidelines for Codex Agents
+
+## Testing
+- Always run `pytest -q` before committing changes to ensure tests pass.
+
+## Style
+- Follow `black` formatting with the default line length (88).
+- Keep imports organized using standard library first, then third party, then local imports.
+
+## Documentation
+- Update `README.md` when scripts or modules change.
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Data Science Project: Kaggle Housing
 
+This repository contains utilities and scripts used to explore and model the Kaggle housing dataset.
+
 ## Structure
 - `data/raw/` - Place raw Kaggle data here
 - `data/processed/` - For cleaned/engineered data
@@ -8,14 +10,16 @@
 - `tests/` - Unit tests
 
 ## Setup
-- Use `requirements.txt` to install dependencies
-- Use Jupyter or VS Code for notebooks
+1. Create a virtual environment and install dependencies:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+2. Launch JupyterLab or VS Code to work with the notebooks.
 
 ## Data Preprocessing
-
-Run the preprocessing script to convert the raw Kaggle data into a cleaned
-dataset. This replicates the steps originally performed in the Jupyter
-notebooks:
+Run the preprocessing script to convert the raw Kaggle data into a cleaned dataset. This replicates the steps originally performed in the Jupyter notebooks:
 
 ```bash
 python scripts/preprocess_data.py \
@@ -23,8 +27,7 @@ python scripts/preprocess_data.py \
   --output data/processed/V1/train_cleaned.csv
 ```
 
-For a more feature-rich preprocessing pipeline that performs scaling and
-one-hot encoding, add `--method advanced`:
+For a more feature-rich preprocessing pipeline that performs scaling and one-hot encoding, add `--method advanced`:
 
 ```bash
 python scripts/preprocess_data.py \
@@ -32,3 +35,19 @@ python scripts/preprocess_data.py \
   --input data/raw/train.csv \
   --output data/processed/V2/train_preprocessed.csv
 ```
+
+## Correlation Analysis
+Use the correlation analysis runner to generate a detailed report of relationships in the processed data:
+
+```bash
+python scripts/correlation_analysis_runner.py --config config/correlation_analysis_config.yaml
+```
+
+## Running Tests
+Run unit tests before committing changes:
+
+```bash
+pytest -q
+```
+
+See `AGENTS.md` for contribution guidelines.


### PR DESCRIPTION
## Summary
- add guidelines for Codex agents in `AGENTS.md`
- expand repo `README` with environment setup, correlation analysis usage and tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: pandas)*

------
https://chatgpt.com/codex/tasks/task_b_683b6707f6808326b502a556df704f48