### PR TITLE
Add model comparison utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,14 @@ python scripts/preprocess_data.py \
   --input data/raw/train.csv \
   --output data/processed/V1/train_cleaned.csv
 ```
+
+## Model Comparison
+
+Use the `compare_models.py` script to evaluate several algorithms with cross-validation and see which performs best. It requires a preprocessed dataset (e.g., from the advanced preprocessing method):
+
+```bash
+python scripts/compare_models.py \
+  --data data/processed/V2/train_advanced_cleaned.csv
+```
+
+The script outputs a table with RMSE, MAE, and R² scores so you can quickly identify the top-performing model.

--- a/models/simple/README.md
+++ b/models/simple/README.md
@@ -7,3 +7,7 @@ Available scripts:
 - `linear_regression.py` - Ordinary least squares regression.
 - `decision_tree_regression.py` - Decision tree regressor.
 - `random_forest_regression.py` - Random forest regressor.
+
+For an easy way to see which of these performs best on your data, run the
+`scripts/compare_models.py` utility after preprocessing. It reports cross-
+validated RMSE, MAE and R² scores for each model.

--- a/scripts/compare_models.py
+++ b/scripts/compare_models.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Compare multiple models using cross-validation."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+# Add src directory to path
+script_dir = Path(__file__).resolve().parent
+project_root = script_dir.parent
+sys.path.append(str(project_root / "src"))
+
+import pandas as pd
+from sklearn.linear_model import LinearRegression
+from sklearn.tree import DecisionTreeRegressor
+from sklearn.ensemble import RandomForestRegressor, GradientBoostingRegressor
+
+from model_evaluator import evaluate_models
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compare model performance")
+    parser.add_argument(
+        "--data",
+        type=str,
+        default="data/processed/V2/train_advanced_cleaned.csv",
+        help="Path to the preprocessed training data",
+    )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="SalePrice",
+        help="Name of the target variable",
+    )
+    parser.add_argument("--cv", type=int, default=5, help="Number of CV folds")
+    args = parser.parse_args()
+
+    print(f"Loading data from {args.data}")
+    df = pd.read_csv(args.data)
+
+    if args.target not in df.columns:
+        raise ValueError(f"Target column {args.target} not found")
+
+    X = df.drop(args.target, axis=1)
+    y = df[args.target]
+
+    models = {
+        "LinearRegression": LinearRegression(),
+        "DecisionTree": DecisionTreeRegressor(random_state=42),
+        "RandomForest": RandomForestRegressor(n_estimators=100, random_state=42),
+        "GradientBoosting": GradientBoostingRegressor(random_state=42),
+    }
+
+    results = evaluate_models(models, X, y, cv=args.cv)
+    print("\nModel comparison (lower RMSE/MAE is better, higher R2 is better):")
+    print(results.to_string(index=False, formatters={"rmse": "{:.2f}".format, "mae": "{:.2f}".format, "r2": "{:.3f}".format}))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,10 +2,12 @@
 
 from .data_cleaner import simple_preprocess, advanced_preprocess
 from .data_analyzer import analyze_dataframe, summarize_csv
+from .model_evaluator import evaluate_models
 
 __all__ = [
     "simple_preprocess",
     "advanced_preprocess",
     "analyze_dataframe",
     "summarize_csv",
+    "evaluate_models",
 ]

--- a/src/model_evaluator.py
+++ b/src/model_evaluator.py
@@ -1,0 +1,81 @@
+"""Utility functions for evaluating and comparing models."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable
+
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import cross_validate
+from sklearn.metrics import (
+    make_scorer,
+    mean_absolute_error,
+    mean_squared_error,
+    r2_score,
+)
+
+
+# ---------------------------------------------------------------------------
+# Scoring utilities
+# ---------------------------------------------------------------------------
+
+
+def _rmse(y_true, y_pred):
+    return np.sqrt(mean_squared_error(y_true, y_pred))
+
+
+RMSE_SCORER = make_scorer(_rmse, greater_is_better=False)
+MAE_SCORER = make_scorer(mean_absolute_error, greater_is_better=False)
+R2_SCORER = make_scorer(r2_score)
+
+
+# ---------------------------------------------------------------------------
+# Public functions
+# ---------------------------------------------------------------------------
+
+
+def evaluate_models(
+    models: Dict[str, object],
+    X: pd.DataFrame,
+    y: pd.Series,
+    cv: int = 5,
+) -> pd.DataFrame:
+    """Evaluate multiple models via cross-validation.
+
+    Parameters
+    ----------
+    models: Dict[str, estimator]
+        Mapping of model name to scikit-learn estimator.
+    X : DataFrame
+        Feature matrix.
+    y : Series
+        Target vector.
+    cv : int, optional
+        Number of CV folds, by default 5.
+
+    Returns
+    -------
+    DataFrame
+        DataFrame with mean RMSE, MAE and R^2 for each model.
+    """
+
+    records = []
+    for name, model in models.items():
+        scores = cross_validate(
+            model,
+            X,
+            y,
+            cv=cv,
+            scoring={"rmse": RMSE_SCORER, "mae": MAE_SCORER, "r2": R2_SCORER},
+            n_jobs=-1,
+        )
+        record = {
+            "model": name,
+            "rmse": -scores["test_rmse"].mean(),
+            "mae": -scores["test_mae"].mean(),
+            "r2": scores["test_r2"].mean(),
+        }
+        records.append(record)
+
+    df = pd.DataFrame(records)
+    return df.sort_values("rmse")

--- a/tests/test_model_evaluator.py
+++ b/tests/test_model_evaluator.py
@@ -1,0 +1,22 @@
+import pandas as pd
+from sklearn.datasets import make_regression
+from sklearn.linear_model import LinearRegression
+from sklearn.tree import DecisionTreeRegressor
+
+from src.model_evaluator import evaluate_models
+
+
+def test_evaluate_models_basic():
+    X, y = make_regression(n_samples=50, n_features=4, noise=0.1, random_state=0)
+    X = pd.DataFrame(X)
+    y = pd.Series(y)
+
+    models = {
+        "lr": LinearRegression(),
+        "tree": DecisionTreeRegressor(random_state=42),
+    }
+
+    results = evaluate_models(models, X, y, cv=3)
+    assert set(results.columns) == {"model", "rmse", "mae", "r2"}
+    assert len(results) == 2
+


### PR DESCRIPTION
## Summary
- implement `src/model_evaluator.py` with a helper for cross‑validated metrics
- export the helper in `src/__init__.py`
- add `scripts/compare_models.py` for quick model benchmarking
- document how to run the comparison script
- update simple models README with usage info
- add unit test for the new evaluator

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_683b67f39f9c83269ad7f18a6b258dba