### PR TITLE
Improve agent JSON export and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,25 @@ python scripts/preprocess_data.py \
   --input data/raw/train.csv \
   --output data/processed/V1/train_cleaned.csv
 ```
+
+## Correlation Analysis
+
+Use the correlation analysis runner to explore relationships between variables.
+The script can optionally save a JSON report of the results:
+
+```bash
+python scripts/correlation_analysis_runner.py \
+  --data data/processed/V1/train_cleaned.csv \
+  --target SalePrice \
+  --output-report analysis_report.json
+```
+
+Add `--quick` to perform only a correlation matrix and high-correlation search.
+
+## Running Tests
+
+Run the unit tests with `pytest`:
+
+```bash
+pytest -q
+```

--- a/tests/test_correlation_analyzer.py
+++ b/tests/test_correlation_analyzer.py
@@ -1,0 +1,22 @@
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")
+
+from src.correlation_analyzer import HousingCorrelationAnalyzer
+
+
+def test_generate_report_output(tmp_path):
+    df = pd.DataFrame({
+        "A": [1, 2, 3, 4],
+        "B": [4, 3, 2, 1],
+        "C": ["x", "y", "x", "y"],
+    })
+
+    analyzer = HousingCorrelationAnalyzer(df)
+    output_file = tmp_path / "report.json"
+    analyzer.generate_comprehensive_report(
+        target_var="A",
+        save_plots=False,
+        output_path=output_file,
+    )
+    assert output_file.exists()


### PR DESCRIPTION
## Summary
- add optional JSON export capability to correlation analyzer
- allow `correlation_analysis_runner.py` to write report via `--output-report`
- document correlation analysis and testing instructions in README
- test report generation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_683b6823871083268bebffda66df572c