### PR TITLE
Add data pipeline and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@
 - `data/processed/` - For cleaned/engineered data
 - `notebooks/` - Jupyter notebooks for EDA and modeling
 - `scripts/` - Python scripts for data processing and modeling
+- `scripts/run_pipeline.py` - Simple pipeline to clean data and create visualizations
 - `tests/` - Unit tests
 
 ## Setup
 - Use `requirements.txt` to install dependencies
 - Use Jupyter or VS Code for notebooks
+- Run the pipeline with `python scripts/run_pipeline.py --input data/raw/train.csv`
+

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Simple command-line interface for running the data pipeline."""
+import argparse
+from pathlib import Path
+import sys
+
+# Add src directory to path
+project_root = Path(__file__).resolve().parents[1]
+sys.path.append(str(project_root / "src"))
+
+from data_pipeline import load_data, clean_data, save_data, create_visualizations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run the data processing pipeline")
+    parser.add_argument("--input", required=True, help="Path to raw data CSV")
+    parser.add_argument(
+        "--output-data",
+        default=str(project_root / "data/processed/cleaned_data.csv"),
+        help="Output path for cleaned data",
+    )
+    parser.add_argument(
+        "--viz-dir",
+        default=str(project_root / "data/processed/visualizations"),
+        help="Directory to save visualizations",
+    )
+    args = parser.parse_args()
+
+    df = load_data(args.input)
+    df_clean = clean_data(df)
+    save_data(df_clean, args.output_data)
+    create_visualizations(df_clean, args.viz_dir)
+
+    print(f"Clean data saved to {args.output_data}")
+    print(f"Visualizations stored in {args.viz_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -1,0 +1,46 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns
+from pathlib import Path
+
+
+def load_data(path: str) -> pd.DataFrame:
+    """Load dataset from a CSV file."""
+    return pd.read_csv(path)
+
+
+def clean_data(df: pd.DataFrame) -> pd.DataFrame:
+    """Simple cleaning: drop rows with missing values."""
+    return df.dropna(axis=0, how="any").reset_index(drop=True)
+
+
+def save_data(df: pd.DataFrame, output_path: str) -> None:
+    """Save DataFrame to CSV, creating directories as needed."""
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(output_path, index=False)
+
+
+def create_visualizations(df: pd.DataFrame, output_dir: str, target: str = "SalePrice") -> None:
+    """Create simple visualizations and save them to disk."""
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    if target in df.columns:
+        plt.figure(figsize=(8, 6))
+        sns.histplot(df[target].dropna(), kde=True)
+        plt.title(f"{target} Distribution")
+        plt.tight_layout()
+        plt.savefig(output_path / f"{target}_distribution.png")
+        plt.close()
+
+    numeric_cols = df.select_dtypes(include=[float, int]).columns
+    if len(numeric_cols) > 1:
+        corr = df[numeric_cols].corr()
+        plt.figure(figsize=(10, 8))
+        sns.heatmap(corr, annot=False, cmap="RdBu_r")
+        plt.title("Correlation Matrix")
+        plt.tight_layout()
+        plt.savefig(output_path / "correlation_matrix.png")
+        plt.close()
+

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -1,0 +1,25 @@
+import pandas as pd
+from data_pipeline import load_data, clean_data, save_data, create_visualizations
+
+
+def test_clean_data_removes_na(tmp_path):
+    data = pd.DataFrame({'A': [1, 2, None], 'SalePrice': [100, 200, 300]})
+    cleaned = clean_data(data)
+    assert cleaned.isna().sum().sum() == 0
+
+    out_csv = tmp_path / "clean.csv"
+    save_data(cleaned, out_csv)
+    assert out_csv.exists()
+
+    viz_dir = tmp_path / "viz"
+    create_visualizations(cleaned, viz_dir)
+    assert (viz_dir / "SalePrice_distribution.png").exists()
+    assert (viz_dir / "correlation_matrix.png").exists()
+
+
+def test_load_data(tmp_path):
+    csv_path = tmp_path / "sample.csv"
+    pd.DataFrame({'A': [1, 2], 'B': [3, 4]}).to_csv(csv_path, index=False)
+    df = load_data(csv_path)
+    assert df.shape == (2, 2)
+


### PR DESCRIPTION
## Summary
- add simple data processing pipeline with visualization saving
- expose pipeline runner CLI
- document pipeline usage in README
- test pipeline helper functions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: pandas, numpy)*

------
https://chatgpt.com/codex/tasks/task_b_683b697e80e083269997e438bd57a62f